### PR TITLE
Add Helm Chart Config Support

### DIFF
--- a/charts/yet-another-aws-exporter/Chart.yaml
+++ b/charts/yet-another-aws-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Yet Another AWS Exporter on Kubernetes
 type: application
 
 # The version of this chart
-version: 0.0.1
+version: 0.0.2
 
 # Corresponds to the release tag of the application
 # https://github.com/cashapp/yet-another-aws-exporter/releases

--- a/charts/yet-another-aws-exporter/README.md
+++ b/charts/yet-another-aws-exporter/README.md
@@ -1,6 +1,6 @@
 # yaae
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
 
 A Helm chart for deploying Yet Another AWS Exporter on Kubernetes
 
@@ -9,6 +9,7 @@ A Helm chart for deploying Yet Another AWS Exporter on Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| disabledScrapers | list | `[]` | A list of scraper IDs to disable in the exporter |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"cashapp/yet-another-aws-exporter"` |  |
@@ -24,9 +25,9 @@ A Helm chart for deploying Yet Another AWS Exporter on Kubernetes
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
-| scrapeInterval | string | `"300s"` |  |
+| scrapeInterval | string | `"300s"` | Specify the scraper interval for Prometheus  |
 | securityContext | object | `{}` |  |
-| serviceAccount.annotations."eks.amazonaws.com/role-arn" | string | `""` |  Add the full role arn if using OIDC for pod role assumption |
+| serviceAccount.annotations."eks.amazonaws.com/role-arn" | string | `""` | Add the full role arn if using OIDC for pod role assumption |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |

--- a/charts/yet-another-aws-exporter/templates/configmap.yaml
+++ b/charts/yet-another-aws-exporter/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if gt (len .Values.disabledScrapers) 0 -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "yet-another-aws-exporter.fullname" . }}-config
+  labels:
+    {{- include "yet-another-aws-exporter.labels" . | nindent 4 }}
+data:
+  yaae.yaml: |-
+    disabledScrapers:
+    {{- toYaml .Values.disabledScrapers | nindent 6 }}
+{{- end }}

--- a/charts/yet-another-aws-exporter/templates/deployment.yaml
+++ b/charts/yet-another-aws-exporter/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: 
             - serve
-            - "-l"
-            - "debug"
           ports:
             - name: metrics
               containerPort: 9100

--- a/charts/yet-another-aws-exporter/templates/deployment.yaml
+++ b/charts/yet-another-aws-exporter/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: 
             - serve
+            - "-l"
+            - "debug"
           ports:
             - name: metrics
               containerPort: 9100
@@ -53,6 +55,19 @@ spec:
               port: metrics
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if gt (len .Values.disabledScrapers) 0 }}
+          volumeMounts:
+            - name: yaae-config
+              mountPath: /exporter/
+              readOnly: true
+          {{- end }}
+      {{- if gt (len .Values.disabledScrapers) 0 }}
+      volumes:
+        - name: yaae-config
+          configMap:
+            name: {{ include "yet-another-aws-exporter.fullname" . }}-config
+            defaultMode: 420
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/yet-another-aws-exporter/templates/podmonitor.yaml
+++ b/charts/yet-another-aws-exporter/templates/podmonitor.yaml
@@ -13,5 +13,5 @@ spec:
   podMetricsEndpoints:
   - port: metrics
     path: /metrics
-    interval: {{ .Values.scapeInterval }} 
+    interval: {{ .Values.scrapeInterval }} 
 {{- end }}

--- a/charts/yet-another-aws-exporter/values.yaml
+++ b/charts/yet-another-aws-exporter/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+# -- Specify the scraper interval for Prometheus 
 scrapeInterval: 300s
 
 image:
@@ -21,8 +22,7 @@ serviceAccount:
   name: ""
   # Annotations to add to the service account
   annotations:
-    #
-    # Add the full role arn if using OIDC for pod role assumption
+    # -- Add the full role arn if using OIDC for pod role assumption
     eks.amazonaws.com/role-arn: "" 
 
 podAnnotations: {}
@@ -45,6 +45,7 @@ tolerations: []
 
 affinity: {}
 
+# -- A list of scraper IDs to disable in the exporter
 disabledScrapers: []
   # - vpcInfo
 

--- a/charts/yet-another-aws-exporter/values.yaml
+++ b/charts/yet-another-aws-exporter/values.yaml
@@ -44,3 +44,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+disabledScrapers: []
+  # - vpcInfo
+


### PR DESCRIPTION
## Description
This PR adds support for the `yaae.yaml` config to the Helm chart so scrapers can be disabled easily.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

It's a new Helm chart feature, but we're still in pre-0.1.x so only bumping as a patch upgrade of the chart.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
